### PR TITLE
Bump hash to the released 2.4.0 build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Nicholas Long nicholas.long@nrel.gov
 
 # Run this separate to cache the download
 ENV OPENSTUDIO_VERSION 2.4.0
-ENV OPENSTUDIO_SHA b2951e5b8d
+ENV OPENSTUDIO_SHA f58a3e1808
 
 # Download from S3
 ENV OPENSTUDIO_DOWNLOAD_BASE_URL https://s3.amazonaws.com/openstudio-builds/$OPENSTUDIO_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM ubuntu:14.04
 MAINTAINER Nicholas Long nicholas.long@nrel.gov
 
 # Run this separate to cache the download
-ENV OPENSTUDIO_VERSION 2.3.1
-ENV OPENSTUDIO_SHA 9b0fc45840
+ENV OPENSTUDIO_VERSION 2.4.0
+ENV OPENSTUDIO_SHA b2951e5b8d
 
 # Download from S3
 ENV OPENSTUDIO_DOWNLOAD_BASE_URL https://s3.amazonaws.com/openstudio-builds/$OPENSTUDIO_VERSION


### PR DESCRIPTION
Update hash to use released build instead of an older one