### PR TITLE
Split dockers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,49 +1,22 @@
-FROM ubuntu:14.04
+# This image uses the base one (ubuntu + dependencies and ruby)
+# and simply installs OpenStudio on it
+# docker build -f Dockerfile -t nrel/openstudio .
+FROM nrel/openstudio:base
 
 MAINTAINER Nicholas Long nicholas.long@nrel.gov
 
-# Run this separate to cache the download
-ENV OPENSTUDIO_VERSION 2.4.1
-ENV OPENSTUDIO_SHA fcd9a4317a
+# Run this separate to cache the download (from S3)
+# Modify the OPENSTUDIO_VERSION and OPENSTUDIO_SHA for new versions
+ENV OPENSTUDIO_VERSION=2.4.1 \
+    OPENSTUDIO_SHA=fcd9a4317a
 
-# Download from S3
-ENV OPENSTUDIO_DOWNLOAD_BASE_URL https://s3.amazonaws.com/openstudio-builds/$OPENSTUDIO_VERSION
-ENV OPENSTUDIO_DOWNLOAD_FILENAME OpenStudio-$OPENSTUDIO_VERSION.$OPENSTUDIO_SHA-Linux.deb
-ENV OPENSTUDIO_DOWNLOAD_URL $OPENSTUDIO_DOWNLOAD_BASE_URL/$OPENSTUDIO_DOWNLOAD_FILENAME
+# Filenames for download from S3
+ENV OPENSTUDIO_DOWNLOAD_FILENAME=OpenStudio-$OPENSTUDIO_VERSION.$OPENSTUDIO_SHA-Linux.deb \
+    OPENSTUDIO_DOWNLOAD_URL=https://s3.amazonaws.com/openstudio-builds/$OPENSTUDIO_VERSION/OpenStudio-$OPENSTUDIO_VERSION.$OPENSTUDIO_SHA-Linux.deb
 
-# Install gdebi, then download and install OpenStudio, then clean up.
-# gdebi handles the installation of OpenStudio's dependencies including Qt5,
-# Boost, and Ruby 2.2.4.
-
-RUN apt-get update && apt-get install -y ca-certificates curl gdebi-core git libglu1 libjpeg8 libfreetype6 libxi6 \
-    build-essential libssl-dev libreadline-dev zlib1g-dev libxml2-dev libdbus-glib-1-2 libfontconfig1 libsm6 \
-    && curl -SLO $OPENSTUDIO_DOWNLOAD_URL \
+# Download OpenStudio and use previously installed gdebi to install it, then clean up.
+RUN curl -SLO $OPENSTUDIO_DOWNLOAD_URL \
     && gdebi -n $OPENSTUDIO_DOWNLOAD_FILENAME \
     && rm -f $OPENSTUDIO_DOWNLOAD_FILENAME \
     && rm -rf /usr/SketchUpPlugin \
     && rm -rf /var/lib/apt/lists/*
-
-# Build and install Ruby 2.0 using rbenv for flexibility
-RUN git clone https://github.com/sstephenson/rbenv.git ~/.rbenv
-RUN git clone https://github.com/sstephenson/ruby-build.git ~/.rbenv/plugins/ruby-build
-RUN RUBY_CONFIGURE_OPTS=--enable-shared ~/.rbenv/bin/rbenv install 2.2.4
-RUN ~/.rbenv/bin/rbenv global 2.2.4
-
-# Add rben path
-RUN echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
-RUN echo 'eval "$(rbenv init -)"' >> ~/.bashrc
-
-# Add bundler gem
-RUN ~/.rbenv/shims/gem install bundler
-
-# Add RUBYLIB link for openstudio.rb and Ruby path based on the shim installed
-ENV RUBYLIB /usr/Ruby
-ENV PATH "/root/.rbenv/shims:$PATH"
-
-# Test file
-COPY test.rb /root/test.rb
-
-VOLUME /var/simdata/openstudio
-WORKDIR /var/simdata/openstudio
-
-CMD [ "/bin/bash" ]

--- a/Dockerfile-Base
+++ b/Dockerfile-Base
@@ -1,0 +1,35 @@
+# This is the base image used to build OpenStudio later
+# From ubuntu, installs all dependencies and Ruby
+# docker build -f Dockerfile-Base -t nrel/openstudio:base .
+FROM ubuntu:14.04
+
+MAINTAINER Julien Marrec julien@effibem.com
+
+# Install gdebi, then download and install OpenStudio, then clean up.
+# gdebi handles the installation of OpenStudio's dependencies including Qt5,
+# Boost, and Ruby 2.2.4.
+RUN apt-get update && apt-get install -y ca-certificates curl gdebi-core git libglu1 libjpeg8 libfreetype6 libxi6 \
+    build-essential libssl-dev libreadline-dev zlib1g-dev libxml2-dev libdbus-glib-1-2 libfontconfig1 libsm6 \
+    && `# Build and install Ruby 2.0 using rbenv for flexibility` \
+    && git clone https://github.com/sstephenson/rbenv.git ~/.rbenv \
+    && git clone https://github.com/sstephenson/ruby-build.git ~/.rbenv/plugins/ruby-build \
+    && RUBY_CONFIGURE_OPTS=--enable-shared ~/.rbenv/bin/rbenv install 2.2.4 \
+    && ~/.rbenv/bin/rbenv global 2.2.4 \
+    && `# Add rbenv path` \
+    && echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(rbenv init -)"' >> ~/.bashrc \
+    && `# Add bundler gem` \
+    && ~/.rbenv/shims/gem install bundler
+
+
+# Add RUBYLIB link for openstudio.rb and Ruby path based on the shim installed
+ENV RUBYLIB=/usr/Ruby \
+    PATH="/root/.rbenv/shims:$PATH"
+
+# Test file
+#COPY test.rb /root/test.rb
+
+VOLUME /var/simdata/openstudio
+WORKDIR /var/simdata/openstudio
+
+CMD [ "/bin/bash" ]

--- a/deploy_docker.sh
+++ b/deploy_docker.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+base_image_name=nrel/openstudio:base
+
 IMAGETAG=skip
 if [ "${TRAVIS_BRANCH}" == "develop" ]; then
     IMAGETAG=develop
@@ -19,7 +21,43 @@ fi
 if [ "${IMAGETAG}" != "skip" ] && [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
     echo "Tagging image as $IMAGETAG"
 
+    # Login to docker
     docker login -u $DOCKER_USER -p $DOCKER_PASS
+
+    # If the base image doesn't already exists, build it
+    if [ -z $(docker images -q $base_image_name) ]; then
+      echo "Building $base_image_name (not found)"
+      docker build -f Dockerfile-Base -t $base_image_name .
+      # Not sure how travis works (can it store the local base image?)
+      # Otherwise push it
+      docker push $base_image_name
+    else
+      # Otherwise, Check whether the base image is older than a month
+      base_image_created_date=$(docker inspect -f '{{ .Created }}' $base_image_name)
+      date_sec_base_image=$(date -d $base_image_created_date +%s)
+      date_sec_now=$(date +%s)
+      older_than_one_month=$(( ($date_sec_now - $date_sec_base_image) > 60*24*30))
+
+      if [ $older_than_one_month ]; then
+        # If older than a month, ask whether the user wants to rebuild
+        # For TRAVIS I guess you can just delete that and force rebuild
+        echo "The base image $base_image_name is older than one month, rebuild? [Y/n]"
+        read -n 1 -r
+        echo    # (optional) move to a new line
+        # Default is yes, so anything else than 'n' will trigger rebuild
+        if [[ ! $REPLY =~ ^[Nn]$ ]]
+        then
+            echo -e "* Rebuilding the base image $base_image_name from Dockerfile-Base"
+            docker rmi $base_image_name
+            docker build -f Dockerfile-Base -t $base_image_name .
+            # Push?
+            docker push $base_image_name
+        fi
+      else
+        echo "Found the base image $base_image_name which is newer than one month"
+      fi
+    fi
+
     docker build -f Dockerfile -t nrel/openstudio:$IMAGETAG -t nrel/openstudio:latest .
     docker push nrel/openstudio:$IMAGETAG
     docker push nrel/openstudio:latest


### PR DESCRIPTION
I realized for CI integration the thing that makes most sense is to split the docker stuff in two because the bottleneck is installing dependencies, and most of all ruby, so I build two Dockerfiles.

* One **base image** that is ubuntu + dependencies + ruby, that you will **build once** (and can rebuild every few months), and takes about 4min and weights 618 MB.
* Then another image that uses the base image and just installs whatever version of OpenStudio you want on top of it. **This will happen a lot more often and takes only 30secs, so you save 4min each time** (if you want nightly builds, that’s quickly huge). Resulting total size is 1.32GB versus 1.38 GB with the current dockerfile, not a huge improvement but it's not worse at least.

I also stubbed a new `deploy_script.sh` that checks the age of the base image, so you can rebuild it every month if you want. You’ll need to define whether you want to push the `nrel/openstudio:base` image to dockerhub too: it depends whether travis can store this base image locally or not, if not then you really want to push it.
Pushed or not, I hope travis can store the local image, that’ll limit the need to pull 618MB of data each time and reduce the environmental impact of the CI...
You may want to delete the `read` stuff for user input too.