### PR TITLE
New install location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 build
+test/compact_osw

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ install:
   - echo "Nothing to install"
 script:
   - docker build -t openstudio:latest .
-  - docker run -it openstudio:latest ruby /root/test.rb
+  - docker run -it -v $(pwd):/var/simdata/openstudio openstudio:latest ruby /var/simdata/openstudio/test/test.rb
 after_success:
   - ./deploy_docker.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,10 @@ MAINTAINER Nicholas Long nicholas.long@nrel.gov
 ARG DOWNLOAD_PREFIX=""
 
 # Modify the OPENSTUDIO_VERSION and OPENSTUDIO_SHA for new versions
-ENV OPENSTUDIO_VERSION=2.5.0 \
-    OPENSTUDIO_SHA=366cbe0e3a \
+ENV OPENSTUDIO_VERSION=2.5.1 \
+    OPENSTUDIO_SHA=4f268e2854 \
     RUBY_VERSION=2.2.4 \
     RUBY_SHA=b6eff568b48e0fda76e5a36333175df049b204e91217aa32a65153cc0cdcb761
-
-ENV OPENSTUDIO_VERSION=2.5.1 \
-    OPENSTUDIO_SHA=2037d55667
 
 # Don't combine with above since ENV vars are not initialized until after the above call
 ENV OPENSTUDIO_DOWNLOAD_FILENAME=OpenStudio-$OPENSTUDIO_VERSION.$OPENSTUDIO_SHA-Linux.deb
@@ -58,7 +55,7 @@ RUN apt-get update && apt-get install -y autoconf \
     && rm -f /usr/local/bin/install_ruby.sh \
     && rm -f $OPENSTUDIO_DOWNLOAD_FILENAME \
     && rm -rf /var/lib/apt/lists/* \
-    && if dpkg --compare-versions "${OPENSTUDIO_VERSION}" "gt" "2.5.0"; then \
+    && if dpkg --compare-versions "${OPENSTUDIO_VERSION}" "gt" "2.5.1"; then \
             rm -rf /usr/local/openstudio-${OPENSTUDIO_VERSION}/SketchUpPlugin; \
        else \
             rm -rf /usr/SketchUpPlugin; \
@@ -66,9 +63,6 @@ RUN apt-get update && apt-get install -y autoconf \
 
 ## Add RUBYLIB link for openstudio.rb. Support new location and old location.
 ENV RUBYLIB=/usr/local/openstudio-${OPENSTUDIO_VERSION}/Ruby:/usr/Ruby
-
-# Test file
-COPY test.rb /root/test.rb
 
 VOLUME /var/simdata/openstudio
 WORKDIR /var/simdata/openstudio

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,21 @@ FROM ubuntu:14.04
 
 MAINTAINER Nicholas Long nicholas.long@nrel.gov
 
-# Run this separate to cache the download (from S3)
+# If installing a CI build version of OpenStudio, then pass in the CI path into the build command. For example:
+#   docker build --build-arg DOWNLOAD_PREFIX="_CI/OpenStudio"
+ARG DOWNLOAD_PREFIX=""
+
 # Modify the OPENSTUDIO_VERSION and OPENSTUDIO_SHA for new versions
 ENV OPENSTUDIO_VERSION=2.5.0 \
     OPENSTUDIO_SHA=366cbe0e3a \
     RUBY_VERSION=2.2.4 \
     RUBY_SHA=b6eff568b48e0fda76e5a36333175df049b204e91217aa32a65153cc0cdcb761
 
-# Filenames for download from S3
-ENV OPENSTUDIO_DOWNLOAD_FILENAME=OpenStudio-$OPENSTUDIO_VERSION.$OPENSTUDIO_SHA-Linux.deb \
-    OPENSTUDIO_DOWNLOAD_URL=https://s3.amazonaws.com/openstudio-builds/$OPENSTUDIO_VERSION/OpenStudio-$OPENSTUDIO_VERSION.$OPENSTUDIO_SHA-Linux.deb
+ENV OPENSTUDIO_VERSION=2.5.1 \
+    OPENSTUDIO_SHA=2037d55667
+
+# Don't combine with above since ENV vars are not initialized until after the above call
+ENV OPENSTUDIO_DOWNLOAD_FILENAME=OpenStudio-$OPENSTUDIO_VERSION.$OPENSTUDIO_SHA-Linux.deb
 
 # Install gdebi, then download and install OpenStudio, then clean up.
 # gdebi handles the installation of OpenStudio's dependencies including Qt5,
@@ -39,14 +44,28 @@ RUN apt-get update && apt-get install -y autoconf \
     && curl -sL https://raw.githubusercontent.com/NREL/OpenStudio-server/develop/docker/deployment/scripts/install_ruby.sh -o /usr/local/bin/install_ruby.sh \
     && chmod +x /usr/local/bin/install_ruby.sh \
     && /usr/local/bin/install_ruby.sh $RUBY_VERSION $RUBY_SHA \
+    && if [ -z "${DOWNLOAD_PREFIX}" ]; then \
+            export OPENSTUDIO_DOWNLOAD_URL=https://openstudio-builds.s3.amazonaws.com/$OPENSTUDIO_VERSION/OpenStudio-$OPENSTUDIO_VERSION.$OPENSTUDIO_SHA-Linux.deb; \
+       else \
+            export OPENSTUDIO_DOWNLOAD_URL=https://openstudio-builds.s3.amazonaws.com/$DOWNLOAD_PREFIX/OpenStudio-$OPENSTUDIO_VERSION.$OPENSTUDIO_SHA-Linux.deb; \
+       fi \
+    && echo "OpenStudio Package Download URL is ${OPENSTUDIO_DOWNLOAD_URL}" \
     && curl -SLO $OPENSTUDIO_DOWNLOAD_URL \
+    # Verify that the download was successful (not access denied XML from s3)
+    && grep -v -q "<Code>AccessDenied</Code>" ${OPENSTUDIO_DOWNLOAD_FILENAME} \
     && gdebi -n $OPENSTUDIO_DOWNLOAD_FILENAME \
+    # Cleanup
+    && rm -f /usr/local/bin/install_ruby.sh \
     && rm -f $OPENSTUDIO_DOWNLOAD_FILENAME \
-    && rm -rf /usr/SketchUpPlugin \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && if dpkg --compare-versions "${OPENSTUDIO_VERSION}" "gt" "2.5.0"; then \
+            rm -rf /usr/local/openstudio-${OPENSTUDIO_VERSION}/SketchUpPlugin; \
+       else \
+            rm -rf /usr/SketchUpPlugin; \
+       fi
 
-## Add RUBYLIB link for openstudio.rb and Ruby path based on the shim installed
-ENV RUBYLIB=/usr/Ruby
+## Add RUBYLIB link for openstudio.rb. Support new location and old location.
+ENV RUBYLIB=/usr/local/openstudio-${OPENSTUDIO_VERSION}/Ruby:/usr/Ruby
 
 # Test file
 COPY test.rb /root/test.rb

--- a/test/test.rb
+++ b/test/test.rb
@@ -1,0 +1,37 @@
+require 'openstudio'
+require 'rubygems'
+require 'fileutils'
+
+# Make sure we can load FFI as it is a very nice dependency
+begin
+  gem 'ffi'
+rescue LoadError
+  system('gem install ffi')
+  system('gem install semantic')
+  Gem.clear_paths
+end
+
+# After installation, then it should be able to require ffi
+require 'ffi'
+require 'semantic'
+require 'semantic/core_ext'
+
+puts "OpenStudio Version: #{OpenStudio.openStudioLongVersion}"
+
+# Should be able to require openstudio-standards, this is ignored for now.
+# require 'openstudio-standards'
+# standard = Standard.build("90.1-2004_SmallOffice")
+# puts standard
+
+# Make sure I can write out an example model
+puts OpenStudio::Model.exampleModel.to_s
+
+# Grab the test files that are shipped with OpenStudio and put into a folder and run
+if OpenStudio.openStudioVersion.to_version <= '2.5.1'.to_version
+  FileUtils.cp_r "/usr/Examples/compact_osw", 'test/.'
+  `/usr/bin/openstudio run -w /var/simdata/openstudio/test/compact_osw/compact.osw`
+else
+  FileUtils.cp_r "/usr/local/openstudio-#{OpenStudio.openStudioVersion}/Examples/compact_osw", 'test/.'
+  `/usr/local/bin/openstudio run -w /var/simdata/openstudio/test/compact_osw/compact.osw`
+end
+raise "Simulation did not run" unless File.exist?('test/compact_osw/run/finished.job')


### PR DESCRIPTION
Formerly the install location of OpenStudio was `/usr` with files such as Ruby being `/usr/Ruby`. This pull request supports the openstudio-x.y.z folder that now exists in `/usr/local/`. 

Requires to support `/usr/local/openstudio-x.y.z/Ruby` and `/usr/local/bin/openstudio`

These changes also support a new ARG for Dockerfile to allow for building a container from an OpenStudio version that is in the CI folder on S3. To use this, simply specify the OPENSTUDIO_VERSION and OPENSTUDIO_SHA in the Dockerfile, and upon build call it with `docker build --build-arg DOWNLOAD_PREFIX="_CI/OpenStudio"`

