### PR TITLE
Split dockers v2

### DIFF
--- a/Dockerfile-Base
+++ b/Dockerfile-Base
@@ -1,0 +1,36 @@
+# This is the base image used to build OpenStudio later
+# From ubuntu, installs all dependencies and Ruby
+# docker build -f Dockerfile-Base -t nrel/openstudio:builder .
+FROM ubuntu:18.04 AS builder
+
+MAINTAINER Julien Marrec julien@effibem.com
+
+# This can be overriden in the build call: `docker build --build-arg OS_BUNDLER_VERSION=2.1.1`
+# But we also set it as an ENV var so it's exported to dependent images and running containers
+ARG OS_BUNDLER_VERSION=2.1.1
+# TODO: This should be 2.5.5, so from rbenv / rvm or a PPA
+ENV RUBY_VERSION=2.5.1
+    OS_BUNDLER_VERSION $OS_BUNDLER_VERSION
+# Install dependencies such as ruby, bundler, git, etc
+# gdebi handles the installation of OpenStudio's dependencies
+# install locales and set to en_US.UTF-8. This is needed for running the CLI on some machines
+# such as singularity.
+
+RUN apt-get update && apt-get install -y \
+        curl \
+        vim \
+        gdebi-core \
+        ruby2.5 \
+        ruby-dev \
+        libffi-dev \
+        build-essential \
+        zlib1g-dev \
+        vim \
+        git \
+        locales \
+        sudo \
+    && rm -rf /var/lib/apt/lists/* \
+    && locale-gen en_US en_US.UTF-8 \
+    && dpkg-reconfigure locales \
+    # The OpenStudio Gemfile contains a fixed bundler version, so you have to install it
+    && gem install bundler -v $OS_BUNDLER_VERSION

--- a/deploy_docker.sh
+++ b/deploy_docker.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+builder_image_name=nrel/openstudio:builder
+
 IMAGETAG=${OPENSTUDIO_VERSION}${OPENSTUDIO_VERSION_EXT}
 echo "image would be tagged as $IMAGETAG if this were master branch"
 IMAGETAG=skip
@@ -13,13 +16,51 @@ fi
 if [ "${IMAGETAG}" != "skip" ] && [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
     echo "Tagging image as $IMAGETAG"
 
+    # Login to docker
     echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+
+    # If the base image doesn't already exists (it should, since it's used as the starting point for the base one we should built)
+    # we build it
+    if [ -z $(docker images -q $builder_image_name) ]; then
+      echo "Building $builder_image_name (not found)"
+      docker build --target builder -t nrel/openstudio:builder .
+      # Not sure how travis works (can it store the local base image?)
+      # Otherwise push it
+      docker push $builder_image_name
+    else
+      # Otherwise, Check whether the base image is older than a month
+      builder_image_created_date=$(docker inspect -f '{{ .Created }}' $builder_image_name)
+      date_sec_builder_image=$(date -d $builder_image_created_date +%s)
+      date_sec_now=$(date +%s)
+      older_than_one_month=$(( ($date_sec_now - $date_sec_builder_image) > 60*24*30))
+
+      if [ $older_than_one_month ]; then
+        # If older than a month, ask whether the user wants to rebuild
+        # For TRAVIS I guess you can just delete that and force rebuild
+        echo "The builder image $builder_image_name is older than one month, rebuild? [Y/n]"
+        read -n 1 -r
+        echo    # (optional) move to a new line
+        # Default is yes, so anything else than 'n' will trigger rebuild
+        if [[ ! $REPLY =~ ^[Nn]$ ]]
+        then
+            echo -e "* Rebuilding the base image $builder_image_name from Dockerfile-Base"
+            docker rmi $builder_image_name
+            docker build -f Dockerfile-Base -t $builder_image_name .
+            # Push?
+            docker push $builder_image_name
+        fi
+      else
+        echo "Found the base image $builder_image_name which is newer than one month"
+      fi
+    fi
+
+
     docker tag openstudio:latest nrel/openstudio:$IMAGETAG; (( exit_status = exit_status || $? ))
     docker tag openstudio:latest nrel/openstudio:latest; (( exit_status = exit_status || $? ))
     docker push nrel/openstudio:$IMAGETAG; (( exit_status = exit_status || $? ))
 
     if [ "${TRAVIS_BRANCH}" == "master" ]; then
-	# Deploy master as the latest.
+        # Deploy master as the latest.
         docker push nrel/openstudio:latest; (( exit_status = exit_status || $? ))
     fi
 


### PR DESCRIPTION
Replace #8 

Not sure what's the best way:
* Two dockerfiles
* One multi-stage dockerfile

If Jenkins was doing the CI, then the multi-stage is probably easier since we can retain the nrel/openstudio:builder on the machine an that part will never have to be rebuilt, and we can just do `FROM builder as base` On travis that's another story.


TODO:
* [ ] Determine best course of action: two dockerfiles or one multi-stage dockerfile.
* [ ] Officially Ruby 2.5.5 should be used, not 2.5.1. So should use either rbenv, rvm or a PPA (such as `sudo apt-add-repository ppa:brightbox/ruby-ng`) to get the 2.5.5