### PR TITLE
Fix SHA for Singularirty Images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ env:
   # setting explicitly in Dockerfile for 
     - OPENSTUDIO_VERSION: 3.0.1
     - OPENSTUDIO_VERSION_EXT: ""
-    # - OPENSTUDIO_SHA: d3ec7ff9b5
-    # - DOWNLOAD_PREFIX: develop3/
+    - OPENSTUDIO_SHA: 09b7c8a554
 jobs:
   include:
     - stage: test and build


### PR DESCRIPTION
fix #106 

Just need to add back in the travis OPENSTUDIO_SHA as this is needed by the singularity build script. 

