### PR TITLE
Add manual GitHub Action installer workflow

### DIFF
--- a/.github/workflows/docker-openstudio.yml
+++ b/.github/workflows/docker-openstudio.yml
@@ -1,4 +1,4 @@
-name: openstudio-server
+name: openstudio-docker
 
 on: [push, pull_request]
 

--- a/.github/workflows/manual_installer_test.yml
+++ b/.github/workflows/manual_installer_test.yml
@@ -52,6 +52,6 @@ jobs:
         docker run -v $(pwd)/test:/var/simdata/openstudio openstudio:latest ./test_gemfile.sh
 
     - name: deploy docker
-       if: ${{ success() }}
-       shell: bash
-       run: ./deploy_docker.sh
+      if: ${{ success() }}
+      shell: bash
+      run: ./deploy_docker.sh

--- a/.github/workflows/manual_installer_test.yml
+++ b/.github/workflows/manual_installer_test.yml
@@ -1,0 +1,57 @@
+name: Test OS SDK Installer - Full Suite
+
+on:
+  workflow_dispatch:
+    inputs:
+      os_installer_link:
+        description: 'The Link where to download the LINUX OpenStudio SDK Installer (.DEB)'
+        required: true
+        default: 'https://openstudio-ci-builds.s3.amazonaws.com/develop/OpenStudio-3.2.0%2Be11f0a08b2-Ubuntu-18.04.deb'
+      os_version:
+        description: 'OS version (e.g. 3.2.0)'
+        required: true
+      os_versioni_ext:
+        description: 'OS version extension (e.g. -alpha)'
+        required: true
+      docker_image_tag:
+        description: 'Docker image tag. Tag name will be prefixed with "dev-" unless tag = "development"'
+        required: true
+
+env:
+  OPENSTUDIO_DOWNLOAD_URL: ${{ github.event.inputs.os_installer_link }} # required
+  OPENSTUDIO_VERSION: ${{ github.event.inputs.os_version }} # required
+  OPENSTUDIO_VERSION_EXT: ${{ github.event.inputs.os_versioni_ext }} # required
+  DOCKER_MANUAL_IMAGE_TAG: ${{ github.event.inputs.docker_image_tag }} # required
+
+jobs:
+  build_container:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.8.x'
+
+    - name: test and build
+      shell: bash
+      run: |
+        set -x
+        echo "Installer link: ${{ github.event.inputs.os_installer_link }}"
+        echo "OS SDK Version: ${{ github.event.inputs.os_version }}"
+        echo "OS SDK Version Extension: ${{ github.event.inputs.os_version_ext }}"
+        echo "DOCKER IMAGE TAG: ${{ github.event.inputs.docker_image_tag }}"
+        sudo apt update
+        docker build --target base -t openstudio:latest \
+        --build-arg OPENSTUDIO_VERSION=$OPENSTUDIO_VERSION \
+        --build-arg OPENSTUDIO_VERSION_EXT=$OPENSTUDIO_VERSION_EXT \
+        --build-arg OPENSTUDIO_DOWNLOAD_URL=$OPENSTUDIO_DOWNLOAD_URL .
+        docker run openstudio:latest openstudio openstudio_version
+        docker run openstudio:latest /usr/local/openstudio-$OPENSTUDIO_VERSION/Radiance/bin/rtrace -version
+        docker run -v $(pwd):/var/simdata/openstudio openstudio:latest ruby /var/simdata/openstudio/test/test_run.rb
+        docker run -v $(pwd)/test:/var/simdata/openstudio openstudio:latest ./test_gemfile.sh
+
+    - name: deploy docker
+       if: ${{ success() }}
+       shell: bash
+       run: ./deploy_docker.sh

--- a/.github/workflows/manual_installer_test.yml
+++ b/.github/workflows/manual_installer_test.yml
@@ -1,4 +1,4 @@
-name: Test OS SDK Installer - Full Suite
+name: Build, test and deploy Docker image
 
 on:
   workflow_dispatch:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,25 +2,14 @@ FROM ubuntu:18.04 AS base
 
 MAINTAINER Nicholas Long nicholas.long@nrel.gov
 
-# If installing a CI build version of OpenStudio, then pass in the CI path into the build command. For example:
-#   docker build --build-arg DOWNLOAD_PREFIX="_CI/OpenStudio"
-# ARG DOWNLOAD_PREFIX=""
-
 # Set the version of OpenStudio when building the container. For example `docker build --build-arg
-# OPENSTUDIO_VERSION=2.6.0 --build-arg OPENSTUDIO_SHA=e3cb91f98a .` in the .travis.yml. Set with the ENV keyword to
-# inherit the variables into child containers
 ARG OPENSTUDIO_VERSION=3.2.0
-ARG OPENSTUDIO_VERSION_EXT
-#ARG OPENSTUDIO_SHA
-ARG OS_BUNDLER_VERSION=2.1.4
+ARG OPENSTUDIO_VERSION_EXT=""
+ARG OPENSTUDIO_DOWNLOAD_URL=https://openstudio-builds.s3.amazonaws.com/3.2.0/OpenStudio-3.2.0%2Be11f0a08b2-Ubuntu-18.04.deb
+
+ENV OS_BUNDLER_VERSION=2.1.4
 ENV RUBY_VERSION=2.7.2
 ENV BUNDLE_WITHOUT=native_ext
-
-# Don't combine with above since ENV vars are not initialized until after the above call
-# ENV OPENSTUDIO_DOWNLOAD_FILENAME=OpenStudio-$OPENSTUDIO_VERSION$OPENSTUDIO_VERSION_EXT.$OPENSTUDIO_SHA-Linux.deb
-
-ENV OPENSTUDIO_DOWNLOAD_FILENAME=OpenStudio-3.2.0%2Be11f0a08b2-Ubuntu-18.04.deb
-
 # Install gdebi, then download and install OpenStudio, then clean up.
 # gdebi handles the installation of OpenStudio's dependencies
 
@@ -39,9 +28,9 @@ RUN apt-get update && apt-get install -y \
         git \
         locales \
         sudo \
-    && export OPENSTUDIO_DOWNLOAD_URL=https://openstudio-builds.s3.amazonaws.com/3.2.0/$OPENSTUDIO_DOWNLOAD_FILENAME \
     && echo "OpenStudio Package Download URL is ${OPENSTUDIO_DOWNLOAD_URL}" \
     && curl -SLO $OPENSTUDIO_DOWNLOAD_URL \
+    && OPENSTUDIO_DOWNLOAD_FILENAME=$(ls *.deb) \
     # Verify that the download was successful (not access denied XML from s3)
     && grep -v -q "<Code>AccessDenied</Code>" ${OPENSTUDIO_DOWNLOAD_FILENAME} \
     && gdebi -n $OPENSTUDIO_DOWNLOAD_FILENAME 
@@ -57,6 +46,7 @@ RUN curl -SLO https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.gz \
     && cd ruby-2.7.2 \
     && ./configure \
     && make && make install 
+
 
 ## Add RUBYLIB link for openstudio.rb
 ENV RUBYLIB=/usr/local/openstudio-${OPENSTUDIO_VERSION}${OPENSTUDIO_VERSION_EXT}/Ruby


### PR DESCRIPTION
Resolves #123 

This adds in a GH actions that allows custom build of docker containers via web GUI on Github actions tab. 

This can also be used to call from a GH actions CLI tool. See: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow




