### PR TITLE
Fixes #166 by updating Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:20.04 AS base
 MAINTAINER Nicholas Long nicholas.long@nrel.gov
 
 # Set the version of OpenStudio when building the container. For example `docker build --build-arg
-ARG OPENSTUDIO_VERSION=3.6.0
+ARG OPENSTUDIO_VERSION=3.6.1
 ARG OPENSTUDIO_VERSION_EXT=""
 ARG OPENSTUDIO_DOWNLOAD_URL=https://github.com/NREL/OpenStudio/releases/download/v3.6.1/OpenStudio-3.6.1+bb9481519e-Ubuntu-20.04-x86_64.deb
 


### PR DESCRIPTION
Makes default ARG OPENSTUDIO_VERSION match the version of OpenStudio actually downloaded and installed