### PR TITLE
Apptainer Builds

### DIFF
--- a/.github/workflows/docker-openstudio.yml
+++ b/.github/workflows/docker-openstudio.yml
@@ -55,20 +55,14 @@ jobs:
         sudo apt update
         sudo apt install -y apptainer
 
-    - name: Upterm
-      uses: lhotari/action-upterm@v1
-      with:
-        limit-access-to-users: nmerket
-
     - name: build apptainer
       shell: bash
       run: |
-        mkdir -p /artifacts
         apptainer build \
-        /artifacts/OpenStudio-$OPENSTUDIO_VERSION$OPENSTUDIO_VERSION_EXT.$OPENSTUDIO_SHA-Apptainer.sif \
+        OpenStudio-$OPENSTUDIO_VERSION$OPENSTUDIO_VERSION_EXT.$OPENSTUDIO_SHA-Apptainer.sif \
         docker://nrel/openstudio:$OPENSTUDIO_VERSION$OPENSTUDIO_VERSION_EXT
     
     - uses: actions/upload-artifact@v3
       with:
         name: apptainer-image
-        path: /artifacts/OpenStudio-$OPENSTUDIO_VERSION$OPENSTUDIO_VERSION_EXT.$OPENSTUDIO_SHA-Apptainer.sif
+        path: OpenStudio-$OPENSTUDIO_VERSION$OPENSTUDIO_VERSION_EXT.$OPENSTUDIO_SHA-Apptainer.sif

--- a/.github/workflows/docker-openstudio.yml
+++ b/.github/workflows/docker-openstudio.yml
@@ -65,4 +65,4 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: apptainer-image
-        path: OpenStudio-$OPENSTUDIO_VERSION$OPENSTUDIO_VERSION_EXT.$OPENSTUDIO_SHA-Apptainer.sif
+        path: OpenStudio-${{ env.OPENSTUDIO_VERSION }}${{ env.OPENSTUDIO_VERSION_EXT }}.${{ env.OPENSTUDIO_SHA }}-Apptainer.sif

--- a/.github/workflows/docker-openstudio.yml
+++ b/.github/workflows/docker-openstudio.yml
@@ -14,6 +14,9 @@ env:
   OPENSTUDIO_SHA: f953b6fcaf
   OPENSTUDIO_VERSION_EXT: ""
 
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   docker:
@@ -48,6 +51,14 @@ jobs:
         DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
         DOCKER_USER: ${{ secrets.DOCKER_USER }}
 
+  apptainer:
+    runs-on: ubuntu-20.04
+    steps: 
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.8.x'
+
     - name: install apptainer
       shell: bash
       run: |
@@ -66,3 +77,18 @@ jobs:
       with:
         name: apptainer-image
         path: OpenStudio-${{ env.OPENSTUDIO_VERSION }}${{ env.OPENSTUDIO_VERSION_EXT }}.${{ env.OPENSTUDIO_SHA }}-Apptainer.sif
+  
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v3
+      with:
+        aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+        role-to-assume: arn:aws:iam::471211731895:role/OpenStudioGitHubActionsRole
+        role-session-name: GitHubActions
+
+    - name: Upload artifacts to AWS S3
+      uses: usualdesigner/s3-artifact-upload@main
+      with:
+        bucket-name: openstudio-builds
+        prefix: ${{env.OPENSTUDIO_VERSION}}
+        file: OpenStudio-${{ env.OPENSTUDIO_VERSION }}${{ env.OPENSTUDIO_VERSION_EXT }}.${{ env.OPENSTUDIO_SHA }}-Apptainer.sif 
+      

--- a/.github/workflows/docker-openstudio.yml
+++ b/.github/workflows/docker-openstudio.yml
@@ -55,6 +55,11 @@ jobs:
         sudo apt update
         sudo apt install -y apptainer
 
+    - name: Upterm
+      uses: lhotari/action-upterm@v1
+      with:
+        limit-access-to-users: nmerket
+
     - name: build apptainer
       shell: bash
       run: |

--- a/.github/workflows/docker-openstudio.yml
+++ b/.github/workflows/docker-openstudio.yml
@@ -65,5 +65,5 @@ jobs:
     
     - uses: actions/upload-artifact@v3
       with:
-        name: singularity-image
+        name: apptainer-image
         path: /artifacts/OpenStudio-$OPENSTUDIO_VERSION$OPENSTUDIO_VERSION_EXT.$OPENSTUDIO_SHA-Apptainer.sif

--- a/.github/workflows/docker-openstudio.yml
+++ b/.github/workflows/docker-openstudio.yml
@@ -48,15 +48,22 @@ jobs:
         DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
         DOCKER_USER: ${{ secrets.DOCKER_USER }}
 
-    - name: deploy singularity
-      if: ${{ success() }} &&  
-        github.ref == 'refs/heads/master' || 
-        github.ref == 'refs/heads/develop' || 
-        github.ref == 'refs/heads/custom_brach_name' 
-      shell: bash 
-      run: ./singularity/deploy_singularity.sh
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+    - name: install apptainer
+      shell: bash
+      run: |
+        sudo add-apt-repository -y ppa:apptainer/ppa
+        sudo apt update
+        sudo apt install -y apptainer
 
+    - name: deploy apptainer
+      shell: bash
+      run: |
+        mkdir -p /artifacts
+        apptainer build \
+        /artifacts/OpenStudio-$OPENSTUDIO_VERSION$OPENSTUDIO_VERSION_EXT.$OPENSTUDIO_SHA-Apptainer.sif \
+        docker://nrel/openstudio:$OPENSTUDIO_VERSION$OPENSTUDIO_VERSION_EXT
+    
+    - uses: actions/upload-artifact@v3
+      with:
+        name: singularity-image
+        path: /artifacts/OpenStudio-$OPENSTUDIO_VERSION$OPENSTUDIO_VERSION_EXT.$OPENSTUDIO_SHA-Apptainer.sif

--- a/.github/workflows/docker-openstudio.yml
+++ b/.github/workflows/docker-openstudio.yml
@@ -55,7 +55,7 @@ jobs:
         sudo apt update
         sudo apt install -y apptainer
 
-    - name: deploy apptainer
+    - name: build apptainer
       shell: bash
       run: |
         mkdir -p /artifacts

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Nicholas Long nicholas.long@nrel.gov
 
 # Set the version of OpenStudio when building the container. For example `docker build --build-arg
 ARG OPENSTUDIO_VERSION=3.8.0
-ARG OPENSTUDIO_VERSION_EXT=""
+ARG OPENSTUDIO_VERSION_EXT="f953b6fcaf"
 ARG OPENSTUDIO_DOWNLOAD_URL=https://openstudio-ci-builds.s3.amazonaws.com/develop/OpenStudio-3.8.0%2Bf953b6fcaf-Ubuntu-20.04-x86_64.deb
 ENV RC_RELEASE=TRUE
 ENV OS_BUNDLER_VERSION=2.4.10


### PR DESCRIPTION
Fixes #174

The apptainer (formerly Singularity) builds of the OpenStudio image are broken. This fixes and updates that.

## To Do

- [x] Verify that the image builds successfully
- [x] Upload apptainer image to S3 if on the correct branch
- [ ] Remove the old singularity folder
