### PR TITLE
Bump CI from 20.04 to 22.04

### DIFF
--- a/.github/workflows/docker-openstudio.yml
+++ b/.github/workflows/docker-openstudio.yml
@@ -10,9 +10,9 @@ on: [push, pull_request]
 
 env:
   USE_TESTING_TIMEOUTS: "true"
-  OPENSTUDIO_VERSION: 3.9.0
-  OPENSTUDIO_SHA: c77fbb9569
-  OPENSTUDIO_VERSION_EXT: ""
+  OPENSTUDIO_VERSION: 3.10.0
+  OPENSTUDIO_SHA: 2B83cec57525
+  OPENSTUDIO_VERSION_EXT: "-alpha"
 
 permissions:
   contents: read

--- a/.github/workflows/docker-openstudio.yml
+++ b/.github/workflows/docker-openstudio.yml
@@ -20,10 +20,10 @@ permissions:
 
 jobs:
   docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps: 
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.8.x'
 
@@ -52,10 +52,10 @@ jobs:
         DOCKER_USER: ${{ secrets.DOCKER_USER }}
 
   apptainer:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps: 
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.8.x'
 
@@ -73,7 +73,7 @@ jobs:
         OpenStudio-$OPENSTUDIO_VERSION$OPENSTUDIO_VERSION_EXT.$OPENSTUDIO_SHA-Apptainer.sif \
         docker://nrel/openstudio:$OPENSTUDIO_VERSION$OPENSTUDIO_VERSION_EXT
     
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: apptainer-image
         path: OpenStudio-${{ env.OPENSTUDIO_VERSION }}${{ env.OPENSTUDIO_VERSION_EXT }}.${{ env.OPENSTUDIO_SHA }}-Apptainer.sif

--- a/.github/workflows/docker-openstudio.yml
+++ b/.github/workflows/docker-openstudio.yml
@@ -71,8 +71,9 @@ jobs:
       run: |
         apptainer build \
         OpenStudio-$OPENSTUDIO_VERSION$OPENSTUDIO_VERSION_EXT.$OPENSTUDIO_SHA-Apptainer.sif \
-#        docker://nrel/openstudio:$OPENSTUDIO_VERSION$OPENSTUDIO_VERSION_EXT
         docker://nrel/openstudio:develop
+        #docker://nrel/openstudio:$OPENSTUDIO_VERSION$OPENSTUDIO_VERSION_EXT
+        
     
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/docker-openstudio.yml
+++ b/.github/workflows/docker-openstudio.yml
@@ -71,7 +71,8 @@ jobs:
       run: |
         apptainer build \
         OpenStudio-$OPENSTUDIO_VERSION$OPENSTUDIO_VERSION_EXT.$OPENSTUDIO_SHA-Apptainer.sif \
-        docker://nrel/openstudio:$OPENSTUDIO_VERSION$OPENSTUDIO_VERSION_EXT
+#        docker://nrel/openstudio:$OPENSTUDIO_VERSION$OPENSTUDIO_VERSION_EXT
+        docker://nrel/openstudio:develop
     
     - uses: actions/upload-artifact@v4
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM ubuntu:22.04 AS base
 MAINTAINER Nicholas Long nicholas.long@nrel.gov
 
 # Set the version of OpenStudio when building the container. For example `docker build --build-arg
-ARG OPENSTUDIO_VERSION=3.9.0
-ARG OPENSTUDIO_VERSION_EXT=""
-ARG OPENSTUDIO_DOWNLOAD_URL="https://openstudio-ci-builds.s3.amazonaws.com/master/OpenStudio-3.9.0%2Bc77fbb9569-Ubuntu-22.04-x86_64.deb"
+ARG OPENSTUDIO_VERSION=3.10.0
+ARG OPENSTUDIO_VERSION_EXT="-alpha"
+ARG OPENSTUDIO_DOWNLOAD_URL="https://openstudio-ci-builds.s3.amazonaws.com/develop/OpenStudio-3.10.0-alpha%2B83cec57525-Ubuntu-22.04-x86_64.deb"
 ENV RC_RELEASE=TRUE
 ENV OS_BUNDLER_VERSION=2.4.10
 ENV RUBY_VERSION=3.2.2
@@ -58,8 +58,8 @@ RUN if [ -d "/usr/local/openstudio-${OPENSTUDIO_VERSION}" ]; then \
     echo "OpenStudio folder is /usr/local/openstudio-${OPENSTUDIO_VERSION}"; \
     OPENSTUDIO_FOLDER=/usr/local/openstudio-${OPENSTUDIO_VERSION}; \
     else \
-    echo "OpenStudio folder is /usr/local/openstudio-${OPENSTUDIO_VERSION}-${OPENSTUDIO_VERSION_EXT}"; \
-    OPENSTUDIO_FOLDER=/usr/local/openstudio-${OPENSTUDIO_VERSION}-${OPENSTUDIO_VERSION_EXT}; \
+    echo "OpenStudio folder is /usr/local/openstudio-${OPENSTUDIO_VERSION}${OPENSTUDIO_VERSION_EXT}"; \
+    OPENSTUDIO_FOLDER=/usr/local/openstudio-${OPENSTUDIO_VERSION}${OPENSTUDIO_VERSION_EXT}; \
     fi \
     && echo "OpenStudio folder is ${OPENSTUDIO_FOLDER}" \
     && rm -rf ruby* \


### PR DESCRIPTION
This uses 3.10.0-alpha so we can test the custom gem fix in OS