### PR TITLE
Refine Docker image tag logic in manual installer workflow

### DIFF
--- a/.github/workflows/manual_installer_test.yml
+++ b/.github/workflows/manual_installer_test.yml
@@ -14,7 +14,7 @@ on:
         description: 'OS version extension (e.g. -alpha). Must match .deb installer'
         required: false
       docker_image_tag:
-        description: 'Docker image tag. Tag name will be prefixed with "dev-" unless tag = "develop"'
+        description: 'Docker image tag. If tag is "develop", it will be "develop". If tag matches a version pattern (e.g. 3.11.0-rc3), it will be used as-is. Otherwise, tag will be prefixed with "dev-".'
         required: true
 
 env:

--- a/deploy_docker.sh
+++ b/deploy_docker.sh
@@ -23,6 +23,8 @@ fi
 if [ ! -z "${DOCKER_MANUAL_IMAGE_TAG}" ]; then
   if [ "${DOCKER_MANUAL_IMAGE_TAG}" == "develop" ]; then
     IMAGETAG="develop"
+  elif [[ "${DOCKER_MANUAL_IMAGE_TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+    IMAGETAG="${DOCKER_MANUAL_IMAGE_TAG}"
   else
     IMAGETAG="dev-${DOCKER_MANUAL_IMAGE_TAG}"
   fi


### PR DESCRIPTION
Enhance the logic for determining the Docker image tag in the manual installer workflow and deploy script to accommodate specific version patterns and improve clarity in the tag description.