### PR TITLE
Add multi-architecture support (amd64 + arm64)

### DIFF
--- a/.github/workflows/docker-openstudio.yml
+++ b/.github/workflows/docker-openstudio.yml
@@ -17,7 +17,7 @@ env:
   OPENSTUDIO_VERSION: 3.11.0
   OPENSTUDIO_SHA: dee62bf9dd
   OPENSTUDIO_VERSION_EXT: "-rc1"
-  OPENSTUDIO_DOWNLOAD_URL: "https://openstudio-ci-builds.s3-us-west-2.amazonaws.com/develop/OpenStudio-3.11.0-rc1%2Bdee62bf9dd-Ubuntu-22.04-x86_64.deb"
+  OPENSTUDIO_DOWNLOAD_URL: "https://openstudio-ci-builds.s3-us-west-2.amazonaws.com/develop/OpenStudio-3.11.0-rc1%2Bdee62bf9dd-Ubuntu-24.04-x86_64.deb"
 
 permissions:
   contents: read

--- a/.github/workflows/docker-openstudio.yml
+++ b/.github/workflows/docker-openstudio.yml
@@ -17,7 +17,7 @@ env:
   OPENSTUDIO_VERSION: 3.11.0
   OPENSTUDIO_SHA: dee62bf9dd
   OPENSTUDIO_VERSION_EXT: "-rc1"
-  OPENSTUDIO_DOWNLOAD_URL: "https://openstudio-ci-builds.s3-us-west-2.amazonaws.com/develop/OpenStudio-3.11.0-rc1%2Bdee62bf9dd-Ubuntu-24.04-x86_64.deb"
+  # Note: OPENSTUDIO_DOWNLOAD_URL is now constructed dynamically in the Dockerfile
 
 permissions:
   contents: read
@@ -30,6 +30,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12.x'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: test and build
         shell: bash

--- a/.github/workflows/manual_installer_test.yml
+++ b/.github/workflows/manual_installer_test.yml
@@ -14,7 +14,7 @@ on:
         description: 'OS version extension (e.g. -alpha). Must match .deb installer'
         required: false
       docker_image_tag:
-        description: 'Docker image tag. Tag name will be prefixed with "dev-" unless tag = "develop"'
+        description: 'Docker image tag. If tag is "develop", it will be "develop". If tag matches a version pattern (e.g. 3.11.0-rc3), it will be used as-is. Otherwise, tag will be prefixed with "dev-".'
         required: true
 
 env:

--- a/.github/workflows/manual_installer_test.yml
+++ b/.github/workflows/manual_installer_test.yml
@@ -6,7 +6,7 @@ on:
       os_installer_link:
         description: 'The Link where to download the LINUX OpenStudio SDK Installer (.DEB)'
         required: true
-        default: 'https://github.com/NREL/OpenStudio/releases/download/v3.4.0/OpenStudio-3.4.0+4bd816f785-Ubuntu-20.04.deb'
+        default: 'https://github.com/NREL/OpenStudio/releases/download/v3.4.0/OpenStudio-3.4.0+4bd816f785-Ubuntu-24.04.deb'
       os_version:
         description: 'OS version (e.g. 3.4.0). Must match .deb installer'
         required: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ ARG OPENSTUDIO_SHA="dee62bf9dd"
 # If OPENSTUDIO_DOWNLOAD_URL is not provided, construct a reasonable default using the
 # OpenStudio CI S3 pattern. Users can override by passing --build-arg OPENSTUDIO_DOWNLOAD_URL=...
 ARG OPENSTUDIO_DOWNLOAD_URL=""
+# TARGETARCH is automatically set by Docker buildx (amd64, arm64, etc.)
+ARG TARGETARCH
 ENV RC_RELEASE=TRUE
 ENV OS_BUNDLER_VERSION=2.4.10
 ENV RUBY_VERSION=3.2.2
@@ -33,10 +35,12 @@ RUN apt-get update && apt-get install -y \
     sudo \
     && if [ -z "${OPENSTUDIO_DOWNLOAD_URL}" ]; then \
     ESC_VERSION=$(echo "${OPENSTUDIO_VERSION}${OPENSTUDIO_VERSION_EXT}" | sed 's/+/%2B/g'); \
+    # Map Docker's TARGETARCH to OpenStudio's architecture naming convention \
+    OS_ARCH=$([ "${TARGETARCH}" = "arm64" ] && echo "arm64" || echo "x86_64"); \
     if [ -n "${OPENSTUDIO_SHA}" ]; then \
-    OPENSTUDIO_DOWNLOAD_URL="https://openstudio-ci-builds.s3.amazonaws.com/develop/OpenStudio-${ESC_VERSION}%2B${OPENSTUDIO_SHA}-Ubuntu-24.04-x86_64.deb"; \
+    OPENSTUDIO_DOWNLOAD_URL="https://openstudio-ci-builds.s3.amazonaws.com/develop/OpenStudio-${ESC_VERSION}%2B${OPENSTUDIO_SHA}-Ubuntu-24.04-${OS_ARCH}.deb"; \
     else \
-    OPENSTUDIO_DOWNLOAD_URL="https://openstudio-ci-builds.s3.amazonaws.com/develop/OpenStudio-${ESC_VERSION}-Ubuntu-24.04-x86_64.deb"; \
+    OPENSTUDIO_DOWNLOAD_URL="https://openstudio-ci-builds.s3.amazonaws.com/develop/OpenStudio-${ESC_VERSION}-Ubuntu-24.04-${OS_ARCH}.deb"; \
     fi; \
     fi \
     && echo "OpenStudio Package Download URL is ${OPENSTUDIO_DOWNLOAD_URL}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 AS base
+FROM ubuntu:24.04 AS base
 
 LABEL maintainer="Nicholas Long nicholas.long@nrel.gov"
 
@@ -34,9 +34,9 @@ RUN apt-get update && apt-get install -y \
     && if [ -z "${OPENSTUDIO_DOWNLOAD_URL}" ]; then \
     ESC_VERSION=$(echo "${OPENSTUDIO_VERSION}${OPENSTUDIO_VERSION_EXT}" | sed 's/+/%2B/g'); \
     if [ -n "${OPENSTUDIO_SHA}" ]; then \
-    OPENSTUDIO_DOWNLOAD_URL="https://openstudio-ci-builds.s3.amazonaws.com/develop/OpenStudio-${ESC_VERSION}%2B${OPENSTUDIO_SHA}-Ubuntu-22.04-x86_64.deb"; \
+    OPENSTUDIO_DOWNLOAD_URL="https://openstudio-ci-builds.s3.amazonaws.com/develop/OpenStudio-${ESC_VERSION}%2B${OPENSTUDIO_SHA}-Ubuntu-24.04-x86_64.deb"; \
     else \
-    OPENSTUDIO_DOWNLOAD_URL="https://openstudio-ci-builds.s3.amazonaws.com/develop/OpenStudio-${ESC_VERSION}-Ubuntu-22.04-x86_64.deb"; \
+    OPENSTUDIO_DOWNLOAD_URL="https://openstudio-ci-builds.s3.amazonaws.com/develop/OpenStudio-${ESC_VERSION}-Ubuntu-24.04-x86_64.deb"; \
     fi; \
     fi \
     && echo "OpenStudio Package Download URL is ${OPENSTUDIO_DOWNLOAD_URL}" \

--- a/deploy_docker.sh
+++ b/deploy_docker.sh
@@ -32,28 +32,36 @@ fi
 
 # GITHUB_BASE_REF is only set on Pull Request events. Do not build those
 if [ "${IMAGETAG}" != "skip" ] && [[ -z "${GITHUB_BASE_REF}" ]]; then
-    echo "Tagging image as $IMAGETAG and pushing to ${DOCKER_REPO}"
+    echo "Building and pushing multi-arch image as $IMAGETAG to ${DOCKER_REPO}"
 
     echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
-    # Tag versioned image
-    docker tag openstudio:latest ${DOCKER_REPO}:$IMAGETAG; (( exit_status = exit_status || $? ))
+
+    # Build tags list
+    TAGS="--tag ${DOCKER_REPO}:${IMAGETAG}"
 
     # Only update and push 'latest' if this is a stable release (no extension)
     if [ -z "${OPENSTUDIO_VERSION_EXT}" ]; then
-        echo "Stable release detected. Updating and pushing '${DOCKER_REPO}:latest'"
-        docker tag openstudio:latest ${DOCKER_REPO}:latest; (( exit_status = exit_status || $? ))
-        docker push ${DOCKER_REPO}:latest; (( exit_status = exit_status || $? ))
+        echo "Stable release detected. Will also push '${DOCKER_REPO}:latest'"
+        TAGS="${TAGS} --tag ${DOCKER_REPO}:latest"
     else
-        echo "Pre-release detected (extension: '${OPENSTUDIO_VERSION_EXT}'). Skipping 'latest' tag update."
+        echo "Pre-release detected (extension: '${OPENSTUDIO_VERSION_EXT}'). Skipping 'latest' tag."
     fi
 
-    # Push versioned tag
-    docker push ${DOCKER_REPO}:$IMAGETAG; (( exit_status = exit_status || $? ))
-    # If on develop branch, also push the develop tag pointing to this image
+    # If on develop branch, also add the develop tag
     if [ "${IMAGETAG}" == "develop" ] || [ "${GITHUB_REF}" == "refs/heads/develop" ]; then
-        docker tag openstudio:latest ${DOCKER_REPO}:develop; (( exit_status = exit_status || $? ))
-        docker push ${DOCKER_REPO}:develop; (( exit_status = exit_status || $? ))
+        TAGS="${TAGS} --tag ${DOCKER_REPO}:develop"
     fi
+
+    # Build and push multi-arch image in one step (required for multi-platform manifests)
+    docker buildx build \
+        --platform=linux/amd64,linux/arm64 \
+        --build-arg OPENSTUDIO_VERSION=${OPENSTUDIO_VERSION} \
+        --build-arg OPENSTUDIO_SHA=${OPENSTUDIO_SHA} \
+        --build-arg OPENSTUDIO_VERSION_EXT=${OPENSTUDIO_VERSION_EXT} \
+        ${TAGS} \
+        --push \
+        .
+    exit_status=$?
 
     exit $exit_status
 else

--- a/deploy_docker.sh
+++ b/deploy_docker.sh
@@ -23,6 +23,8 @@ fi
 if [ ! -z "${DOCKER_MANUAL_IMAGE_TAG}" ]; then
   if [ "${DOCKER_MANUAL_IMAGE_TAG}" == "develop" ]; then
     IMAGETAG="develop"
+  elif [[ "${DOCKER_MANUAL_IMAGE_TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+    IMAGETAG="${DOCKER_MANUAL_IMAGE_TAG}"
   else
     IMAGETAG="dev-${DOCKER_MANUAL_IMAGE_TAG}"
   fi


### PR DESCRIPTION
## Summary

This PR adds support for building multi-architecture Docker images (linux/amd64 and linux/arm64), addressing the request in #85.

### Changes

- **Dockerfile**: Use `TARGETARCH` build arg (automatically set by Docker buildx) to dynamically select the correct OpenStudio package based on target platform
- **CI workflow**: Add QEMU and Docker Buildx setup steps for cross-platform builds
- **deploy_docker.sh**: Replace `docker tag` + `docker push` with `docker buildx build --push --platform=linux/amd64,linux/arm64` (required for multi-platform manifests)

### Why this works now

OpenStudio has been providing ARM64 builds for Ubuntu since v3.8.0:
- `OpenStudio-X.X.X-Ubuntu-24.04-arm64.deb`
- `OpenStudio-X.X.X-Ubuntu-24.04-x86_64.deb`

### Testing

The existing test suite runs on amd64 (CI runners). The ARM64 build uses the same Dockerfile with TARGETARCH selecting the appropriate package.
