### PR TITLE
feat: add workflow_dispatch for on-demand .sif builds and update to ubuntu-24.04

### DIFF
--- a/.github/workflows/docker-openstudio.yml
+++ b/.github/workflows/docker-openstudio.yml
@@ -17,7 +17,7 @@ env:
   OPENSTUDIO_VERSION: 3.11.0
   OPENSTUDIO_SHA: dee62bf9dd
   OPENSTUDIO_VERSION_EXT: "-rc1"
-  OPENSTUDIO_DOWNLOAD_URL: "https://openstudio-ci-builds.s3-us-west-2.amazonaws.com/develop/OpenStudio-3.11.0-rc1%2Bdee62bf9dd-Ubuntu-22.04-x86_64.deb"
+  OPENSTUDIO_DOWNLOAD_URL: "https://openstudio-ci-builds.s3-us-west-2.amazonaws.com/develop/OpenStudio-3.11.0-rc1%2Bdee62bf9dd-Ubuntu-24.04-x86_64.deb"
 
 permissions:
   contents: read

--- a/.github/workflows/docker-openstudio.yml
+++ b/.github/workflows/docker-openstudio.yml
@@ -2,6 +2,9 @@ name: openstudio-docker
 
 on:
   push:
+    branches:
+      - master
+      - develop
   pull_request:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/docker-openstudio.yml
+++ b/.github/workflows/docker-openstudio.yml
@@ -1,6 +1,27 @@
 name: openstudio-docker
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      openstudio_version:
+        description: 'OpenStudio version (e.g. 3.10.0)'
+        required: true
+        default: '3.11.0'
+      openstudio_sha:
+        description: 'OpenStudio git SHA'
+        required: true
+        default: 'dee62bf9dd'
+      openstudio_version_ext:
+        description: 'Version extension (e.g. -rc1). Leave empty for a final release.'
+        required: false
+        default: '-rc1'
+      apptainer_only:
+        description: 'Skip docker build/test and only build the .sif from an existing Docker Hub image'
+        required: false
+        default: 'false'
+        type: boolean
 
 # example of how to restrict to one branch and push event
 #on:
@@ -31,7 +52,16 @@ jobs:
         with:
           python-version: '3.12.x'
 
+      - name: Resolve version inputs
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        shell: bash
+        run: |
+          echo "OPENSTUDIO_VERSION=${{ github.event.inputs.openstudio_version }}" >> $GITHUB_ENV
+          echo "OPENSTUDIO_SHA=${{ github.event.inputs.openstudio_sha }}" >> $GITHUB_ENV
+          echo "OPENSTUDIO_VERSION_EXT=${{ github.event.inputs.openstudio_version_ext }}" >> $GITHUB_ENV
+
       - name: test and build
+        if: ${{ github.event.inputs.apptainer_only != 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -57,7 +87,7 @@ jobs:
   apptainer:
     runs-on: ubuntu-24.04
     needs: docker
-    if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/custom_branch_name' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/custom_branch_name' }}
     permissions:
       contents: read
       id-token: write
@@ -66,6 +96,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12.x'
+
+      - name: Resolve version inputs
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        shell: bash
+        run: |
+          echo "OPENSTUDIO_VERSION=${{ github.event.inputs.openstudio_version }}" >> $GITHUB_ENV
+          echo "OPENSTUDIO_SHA=${{ github.event.inputs.openstudio_sha }}" >> $GITHUB_ENV
+          echo "OPENSTUDIO_VERSION_EXT=${{ github.event.inputs.openstudio_version_ext }}" >> $GITHUB_ENV
 
       - name: install apptainer
         shell: bash

--- a/.github/workflows/docker-openstudio.yml
+++ b/.github/workflows/docker-openstudio.yml
@@ -2,10 +2,10 @@ name: openstudio-docker
 
 on:
   push:
+  pull_request:
     branches:
       - master
       - develop
-  pull_request:
   workflow_dispatch:
     inputs:
       openstudio_version:

--- a/.github/workflows/docker-openstudio.yml
+++ b/.github/workflows/docker-openstudio.yml
@@ -2,10 +2,10 @@ name: openstudio-docker
 
 on:
   push:
-  pull_request:
     branches:
       - master
       - develop
+  pull_request:
   workflow_dispatch:
     inputs:
       openstudio_version:

--- a/.github/workflows/docker-openstudio.yml
+++ b/.github/workflows/docker-openstudio.yml
@@ -14,9 +14,9 @@ on:
         required: true
         default: 'dee62bf9dd'
       openstudio_version_ext:
-        description: 'Version extension (e.g. -rc1). Leave empty for a final release.'
+        description: 'Version extension (e.g. -rc1). Leave blank for a final release. Default: -rc1'
         required: false
-        default: '-rc1'
+        default: ''
       apptainer_only:
         description: 'Skip docker build/test and only build the .sif from an existing Docker Hub image'
         required: false
@@ -44,21 +44,48 @@ permissions:
   contents: read
 
 jobs:
-  docker:
+  setup:
     runs-on: ubuntu-24.04
+    outputs:
+      openstudio_version:     ${{ steps.resolve.outputs.openstudio_version }}
+      openstudio_sha:         ${{ steps.resolve.outputs.openstudio_sha }}
+      openstudio_version_ext: ${{ steps.resolve.outputs.openstudio_version_ext }}
+    steps:
+      - name: Resolve version
+        id: resolve
+        shell: bash
+        run: |
+          # Start from workflow-level defaults
+          VERSION="${OPENSTUDIO_VERSION}"
+          SHA="${OPENSTUDIO_SHA}"
+          EXT="${OPENSTUDIO_VERSION_EXT}"
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            # Override version/sha if provided (they are required inputs so always non-empty)
+            VERSION="${{ inputs.openstudio_version }}"
+            SHA="${{ inputs.openstudio_sha }}"
+            # Unconditionally assign ext — empty string IS a valid value (final release)
+            # Do NOT use || here: "" || "-rc1" evaluates to "-rc1" in GHA expressions
+            EXT="${{ inputs.openstudio_version_ext }}"
+          fi
+
+          echo "openstudio_version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "openstudio_sha=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "openstudio_version_ext=${EXT}" >> "$GITHUB_OUTPUT"
+          echo "Resolved: OpenStudio ${VERSION}${EXT} (${SHA})"
+
+  docker:
+    needs: setup
+    runs-on: ubuntu-24.04
+    env:
+      OPENSTUDIO_VERSION:     ${{ needs.setup.outputs.openstudio_version }}
+      OPENSTUDIO_SHA:         ${{ needs.setup.outputs.openstudio_sha }}
+      OPENSTUDIO_VERSION_EXT: ${{ needs.setup.outputs.openstudio_version_ext }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12.x'
-
-      - name: Resolve version inputs
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        shell: bash
-        run: |
-          echo "OPENSTUDIO_VERSION=${{ github.event.inputs.openstudio_version }}" >> $GITHUB_ENV
-          echo "OPENSTUDIO_SHA=${{ github.event.inputs.openstudio_sha }}" >> $GITHUB_ENV
-          echo "OPENSTUDIO_VERSION_EXT=${{ github.event.inputs.openstudio_version_ext }}" >> $GITHUB_ENV
 
       - name: test and build
         if: ${{ github.event.inputs.apptainer_only != 'true' }}
@@ -86,8 +113,12 @@ jobs:
 
   apptainer:
     runs-on: ubuntu-24.04
-    needs: docker
+    needs: [setup, docker]
     if: ${{ github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/custom_branch_name' }}
+    env:
+      OPENSTUDIO_VERSION:     ${{ needs.setup.outputs.openstudio_version }}
+      OPENSTUDIO_SHA:         ${{ needs.setup.outputs.openstudio_sha }}
+      OPENSTUDIO_VERSION_EXT: ${{ needs.setup.outputs.openstudio_version_ext }}
     permissions:
       contents: read
       id-token: write
@@ -96,14 +127,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12.x'
-
-      - name: Resolve version inputs
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        shell: bash
-        run: |
-          echo "OPENSTUDIO_VERSION=${{ github.event.inputs.openstudio_version }}" >> $GITHUB_ENV
-          echo "OPENSTUDIO_SHA=${{ github.event.inputs.openstudio_sha }}" >> $GITHUB_ENV
-          echo "OPENSTUDIO_VERSION_EXT=${{ github.event.inputs.openstudio_version_ext }}" >> $GITHUB_ENV
 
       - name: install apptainer
         shell: bash

--- a/.github/workflows/manual_installer_test.yml
+++ b/.github/workflows/manual_installer_test.yml
@@ -14,7 +14,7 @@ on:
         description: 'OS version extension (e.g. -alpha). Must match .deb installer'
         required: false
       docker_image_tag:
-        description: 'Docker image tag. Tag name will be prefixed with "dev-" unless tag = "develop"'
+        description: 'Docker image tag. If tag is "develop", it will be "develop". If tag matches a version pattern (e.g. 3.11.0-rc3), it will be used as-is. Otherwise, tag will be prefixed with "dev-".'
         required: true
 
 env:

--- a/.github/workflows/manual_installer_test.yml
+++ b/.github/workflows/manual_installer_test.yml
@@ -6,7 +6,7 @@ on:
       os_installer_link:
         description: 'The Link where to download the LINUX OpenStudio SDK Installer (.DEB)'
         required: true
-        default: 'https://github.com/NREL/OpenStudio/releases/download/v3.4.0/OpenStudio-3.4.0+4bd816f785-Ubuntu-20.04.deb'
+        default: 'https://github.com/NREL/OpenStudio/releases/download/v3.4.0/OpenStudio-3.4.0+4bd816f785-Ubuntu-24.04.deb'
       os_version:
         description: 'OS version (e.g. 3.4.0). Must match .deb installer'
         required: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 AS base
+FROM ubuntu:24.04 AS base
 
 LABEL maintainer="Nicholas Long nicholas.long@nrel.gov"
 
@@ -34,9 +34,9 @@ RUN apt-get update && apt-get install -y \
     && if [ -z "${OPENSTUDIO_DOWNLOAD_URL}" ]; then \
     ESC_VERSION=$(echo "${OPENSTUDIO_VERSION}${OPENSTUDIO_VERSION_EXT}" | sed 's/+/%2B/g'); \
     if [ -n "${OPENSTUDIO_SHA}" ]; then \
-    OPENSTUDIO_DOWNLOAD_URL="https://openstudio-ci-builds.s3.amazonaws.com/develop/OpenStudio-${ESC_VERSION}%2B${OPENSTUDIO_SHA}-Ubuntu-22.04-x86_64.deb"; \
+    OPENSTUDIO_DOWNLOAD_URL="https://openstudio-ci-builds.s3.amazonaws.com/develop/OpenStudio-${ESC_VERSION}%2B${OPENSTUDIO_SHA}-Ubuntu-24.04-x86_64.deb"; \
     else \
-    OPENSTUDIO_DOWNLOAD_URL="https://openstudio-ci-builds.s3.amazonaws.com/develop/OpenStudio-${ESC_VERSION}-Ubuntu-22.04-x86_64.deb"; \
+    OPENSTUDIO_DOWNLOAD_URL="https://openstudio-ci-builds.s3.amazonaws.com/develop/OpenStudio-${ESC_VERSION}-Ubuntu-24.04-x86_64.deb"; \
     fi; \
     fi \
     && echo "OpenStudio Package Download URL is ${OPENSTUDIO_DOWNLOAD_URL}" \

--- a/deploy_docker.sh
+++ b/deploy_docker.sh
@@ -23,6 +23,8 @@ fi
 if [ ! -z "${DOCKER_MANUAL_IMAGE_TAG}" ]; then
   if [ "${DOCKER_MANUAL_IMAGE_TAG}" == "develop" ]; then
     IMAGETAG="develop"
+  elif [[ "${DOCKER_MANUAL_IMAGE_TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+    IMAGETAG="${DOCKER_MANUAL_IMAGE_TAG}"
   else
     IMAGETAG="dev-${DOCKER_MANUAL_IMAGE_TAG}"
   fi


### PR DESCRIPTION
## Summary

This PR adds the ability to manually trigger Apptainer `.sif` builds for any OpenStudio version via `workflow_dispatch`, and includes previously-ready ubuntu-24.04 and image tag logic updates.

## Changes

### Workflow dispatch for on-demand `.sif` builds (`docker-openstudio.yml`)
- Added `workflow_dispatch` trigger with inputs:
  - `openstudio_version` — e.g. `3.10.0`
  - `openstudio_sha` — git SHA for the release
  - `openstudio_version_ext` — e.g. `-rc1`, or **blank for a final release**
  - `apptainer_only` — skip docker build/test and pull directly from an existing Docker Hub image
- Added a `setup` job that resolves version inputs via `GITHUB_OUTPUT`, fixing a subtle GitHub Actions bug where empty string inputs (needed for final releases with no version extension) were silently replaced by the input's `default:` value before bash ran. Using `GITHUB_OUTPUT` instead of `GITHUB_ENV` and avoiding the `||` operator for the ext variable ensures empty string is preserved correctly.
- `docker` and `apptainer` jobs now consume resolved versions from `needs.setup.outputs`
- `apptainer` job now runs on `workflow_dispatch` events in addition to pushes to `master`/`develop`

### ubuntu-24.04 runner update and image tag logic
- Updated runners from ubuntu-22.04 to ubuntu-24.04
- Refined Docker image tag logic in `manual_installer_test.yml` and `deploy_docker.sh`

## Motivation

The `3.10.0` final release `.sif` was never uploaded to S3 because the CI run on the release commit failed. This workflow change allows backfilling missed releases without touching `master`/`develop` directly.