### PR TITLE
Skip deploy step for Apptainer and update AWS credentials

### DIFF
--- a/.github/workflows/docker-openstudio.yml
+++ b/.github/workflows/docker-openstudio.yml
@@ -53,6 +53,7 @@ jobs:
       openstudio_version:     ${{ steps.resolve.outputs.openstudio_version }}
       openstudio_sha:         ${{ steps.resolve.outputs.openstudio_sha }}
       openstudio_version_ext: ${{ steps.resolve.outputs.openstudio_version_ext }}
+      openstudio_download_url: ${{ steps.resolve.outputs.openstudio_download_url }}
     steps:
       - name: Resolve version
         id: resolve
@@ -72,10 +73,20 @@ jobs:
             EXT="${{ inputs.openstudio_version_ext }}"
           fi
 
+          if [ -n "${EXT}" ]; then
+            ESC_VERSION=$(echo "${VERSION}${EXT}" | sed 's/+/%2B/g')
+            DOWNLOAD_URL="https://openstudio-ci-builds.s3-us-west-2.amazonaws.com/develop/OpenStudio-${ESC_VERSION}%2B${SHA}-Ubuntu-24.04-x86_64.deb"
+          else
+            SHA10="${SHA:0:10}"
+            DOWNLOAD_URL="https://github.com/NatLabRockies/OpenStudio/releases/download/v${VERSION}/OpenStudio-${VERSION}%2B${SHA10}-Ubuntu-24.04-x86_64.deb"
+          fi
+
           echo "openstudio_version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "openstudio_sha=${SHA}" >> "$GITHUB_OUTPUT"
           echo "openstudio_version_ext=${EXT}" >> "$GITHUB_OUTPUT"
+          echo "openstudio_download_url=${DOWNLOAD_URL}" >> "$GITHUB_OUTPUT"
           echo "Resolved: OpenStudio ${VERSION}${EXT} (${SHA})"
+          echo "Resolved download URL: ${DOWNLOAD_URL}"
 
   docker:
     needs: setup
@@ -84,6 +95,7 @@ jobs:
       OPENSTUDIO_VERSION:     ${{ needs.setup.outputs.openstudio_version }}
       OPENSTUDIO_SHA:         ${{ needs.setup.outputs.openstudio_sha }}
       OPENSTUDIO_VERSION_EXT: ${{ needs.setup.outputs.openstudio_version_ext }}
+      OPENSTUDIO_DOWNLOAD_URL: ${{ needs.setup.outputs.openstudio_download_url }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -98,7 +110,8 @@ jobs:
           docker build -t openstudio:latest \
             --build-arg OPENSTUDIO_VERSION=$OPENSTUDIO_VERSION \
             --build-arg OPENSTUDIO_SHA=$OPENSTUDIO_SHA \
-            --build-arg OPENSTUDIO_VERSION_EXT=$OPENSTUDIO_VERSION_EXT .
+            --build-arg OPENSTUDIO_VERSION_EXT=$OPENSTUDIO_VERSION_EXT \
+            --build-arg OPENSTUDIO_DOWNLOAD_URL=$OPENSTUDIO_DOWNLOAD_URL .
           docker run openstudio:latest openstudio openstudio_version
           docker run openstudio:latest /usr/local/openstudio-$OPENSTUDIO_VERSION/Radiance/bin/rtrace -version
           docker run -v "$(pwd)":/var/simdata/openstudio openstudio:latest ruby /var/simdata/openstudio/test/test_run.rb

--- a/.github/workflows/docker-openstudio.yml
+++ b/.github/workflows/docker-openstudio.yml
@@ -154,7 +154,7 @@ jobs:
           path: OpenStudio-${{ env.OPENSTUDIO_VERSION }}${{ env.OPENSTUDIO_VERSION_EXT }}.${{ env.OPENSTUDIO_SHA }}-Apptainer.sif
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
           role-to-assume: arn:aws:iam::471211731895:role/OpenStudioGitHubActionsRole

--- a/.github/workflows/docker-openstudio.yml
+++ b/.github/workflows/docker-openstudio.yml
@@ -105,7 +105,7 @@ jobs:
           docker run -v "$(pwd)/test":/var/simdata/openstudio openstudio:latest ./test_gemfile.sh
 
       - name: deploy docker
-        if: ${{ success() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/custom_branch_name') }}
+        if: ${{ success() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/custom_branch_name') && !(github.event_name == 'workflow_dispatch' && inputs.apptainer_only) }}
         shell: bash
         run: |
           set -euo pipefail
@@ -113,6 +113,7 @@ jobs:
         env:
           DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_MANUAL_IMAGE_TAG: ${{ inputs.docker_manual_image_tag }}
 
   apptainer:
     runs-on: ubuntu-24.04

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenStudio
 
-[![openstudio-docker](https://github.com/NREL/docker-openstudio/actions/workflows/docker-openstudio.yml/badge.svg)](https://github.com/NREL/docker-openstudio/actions/workflows/docker-openstudio.yml)
+[![openstudio-docker](https://github.com/NatLabRockies/docker-openstudio/actions/workflows/docker-openstudio.yml/badge.svg)](https://github.com/NatLabRockies/docker-openstudio/actions/workflows/docker-openstudio.yml)
 
 This repo provides a container for OpenStudio as well as several dependencies, including Ruby 2.x, Bundler, 
 build-essentials and various development libraries for gem support.
@@ -16,7 +16,7 @@ Below is a table of the various docker tags and their meanings as seen on [this 
 |---------|-----------------------------------------------------------------------------------------|
 | x.y.z   | Build of official OpenStudio release (recommended use)                                  |
 | latest  | Latest official release of OpenStudio (e.g. 2.5.1)                                      |
-| develop | Release of [develop branch](https://github.com/NREL/docker-openstudio/tree/develop)     |
+| develop | Release of [develop branch](https://github.com/NatLabRockies/docker-openstudio/tree/develop)     |
 
 ## Building OpenStudio Container
 
@@ -84,7 +84,7 @@ If gem dependencies are required as part of the CLI outside of those
 
 # Issues
 
-Please submit issues on the project's [Github](https://github.com/nrel/docker-openstudio) page. 
+Please submit issues on the project's [Github](https://github.com/NatLabRockies/docker-openstudio) page. 
 
 ## Building and publishing specific OpenStudio versions
 


### PR DESCRIPTION
Skip the deploy step for the Docker workflow when running in Apptainer-only mode. Update the AWS credentials action version and correct repository links in the README. Add dynamic download URL generation for OpenStudio based on version and SHA.